### PR TITLE
Let integration-tests know about latest WP versions

### DIFF
--- a/.github/workflows/reusable-integration-tests.yml
+++ b/.github/workflows/reusable-integration-tests.yml
@@ -69,6 +69,10 @@ jobs:
       run: |
         if [ "${{ inputs.wp }}" == "latest" ]; then
           composer install --dev --prefer-dist
+        elif [ "${{ inputs.wp }}" == "latest-1" ]; then
+          composer require --dev --update-with-dependencies --prefer-dist roots/wordpress-full="~6.4.0"
+        elif [ "${{ inputs.wp }}" == "latest-2" ]; then
+          composer require --dev --update-with-dependencies --prefer-dist roots/wordpress-full="~6.3.0"
         elif [ "${{ inputs.wp }}" == "nightly" ]; then
           composer require --dev --update-with-dependencies --prefer-dist roots/wordpress-full="dev-main"
         else


### PR DESCRIPTION
@johnbillion So you can say
```yaml
wp:
  - latest
  - latest-1
  - latest-2
```
and **not** update repos using this workflow every time.
