### PR TITLE
Re-enable shellcheck in actionlint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Run actionlint
         uses: docker://rhysd/actionlint:latest
         with:
-          args: "-color -verbose -shellcheck="
+          args: "-color -verbose"
 
   octoscan:
     name: Octoscan


### PR DESCRIPTION
Not yet sure if this will result in some duplicate errors between actionlint and octoscan.