### PR TITLE
Update zizmor from 1.9.0 to 1.11.0

### DIFF
--- a/.github/workflows/reusable-workflow-lint.yml
+++ b/.github/workflows/reusable-workflow-lint.yml
@@ -69,7 +69,7 @@ jobs:
         uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v6.3.1
 
       - name: Run zizmor
-        run: uvx zizmor@1.9.0 --format sarif . > results.sarif
+        run: uvx zizmor@1.11.0 --format sarif . > results.sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
• Updates zizmor static analysis tool from version 1.9.0 to 1.11.0

## Test plan
- [ ] Verify workflow runs successfully with new zizmor version
- [ ] Check that SARIF output is generated correctly

🤖 Generated with [Claude Code](https://claude.ai/code)